### PR TITLE
Worldedit block tracking and more

### DIFF
--- a/CCSActivityTracker/src/org/cinemacraftstudios/PlayerStats/PlayerStats.java
+++ b/CCSActivityTracker/src/org/cinemacraftstudios/PlayerStats/PlayerStats.java
@@ -12,7 +12,6 @@ import java.util.UUID;
  */
 public class PlayerStats {
 	private UUID uuid;
-	private String name;
 	private ArrayList<Session> sessions = new ArrayList<Session>();
 
 	public PlayerStats(UUID uuid) {
@@ -23,25 +22,11 @@ public class PlayerStats {
 		return this.uuid;
 	}
 
-	public String GetName() {
-		return name;
-	}
-
-	public void SetName(String name) {
-		this.name = name;
-	}
-
 	public ArrayList<Session> GetSessions() {
 		return sessions;
 	}
 
 	public void SetSessions(ArrayList<Session> sessions) {
 		this.sessions = sessions;
-	}
-
-	public Session getCurrentSession() {
-		// Gets the last session. This should be the last one
-		// But depends on if one was created.
-		return this.sessions.get(this.sessions.size() - 1);
 	}
 }

--- a/CCSActivityTracker/src/org/cinemacraftstudios/PlayerStats/PlayerStatsFileManager.java
+++ b/CCSActivityTracker/src/org/cinemacraftstudios/PlayerStats/PlayerStatsFileManager.java
@@ -9,29 +9,31 @@ import java.io.InputStreamReader;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
+import org.cinemacraftstudios.api.APIInterface;
 
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
 
 /**
- * This class handles saving and loading PlayerStats instances.
+ * This class handles saving and loading PlayerStats instances to the local
+ * filesystem
  * 
  * @author Simon U.
  * 
  */
-public abstract class PlayerStatsFileManager {
+public class PlayerStatsFileManager implements APIInterface {
 	// This location is relative to the jar file (I believe).
-	public static final String FOLDER_LOCATION = "./PlayerStats/";
-	private static Gson gson = new Gson();
+	public final String FOLDER_LOCATION = "./PlayerStats/";
+	private Gson gson = new Gson();
 
 	/**
-	 * Saves a PlayerStats to a folder Works by converting the PlayerStats to json and
-	 * then storing it in the specified location This can be replaced with a real
-	 * database in the future.
+	 * Saves a PlayerStats to a folder Works by converting the PlayerStats to json
+	 * and then storing it in the specified location This can be replaced with a
+	 * real database in the future.
 	 * 
 	 * @param log
 	 */
-	public static void SavePlayerStatsToFile(PlayerStats log) {
+	private void savePlayerStatsToFile(PlayerStats log) {
 		// Convert PlayerStats object to JSON
 		String json = gson.toJson(log);
 
@@ -52,8 +54,6 @@ public abstract class PlayerStatsFileManager {
 			}
 		}
 
-//		Bukkit.getLogger().finer(playerFile.getAbsolutePath());
-
 		try {
 			FileWriter playerWriter;
 			playerWriter = new FileWriter(playerFile.getAbsoluteFile(), false);
@@ -69,18 +69,18 @@ public abstract class PlayerStatsFileManager {
 	}
 
 	/**
-	 * Loads the PlayerStats that matches the uuid. Converts the json to a PlayerStats
-	 * instance. If no file is found, then it creates a new instance of PlayerStats
+	 * Loads the PlayerStats that matches the uuid. Converts the json to a
+	 * PlayerStats instance. If no file is found, then it creates a new instance of
+	 * PlayerStats
 	 * 
 	 * @param uuid
 	 * @return
 	 */
-	public static PlayerStats ReadPlayerStatsFromFile(UUID uuid) {
+	private PlayerStats readPlayerStatsFromFile(UUID uuid) {
 		File playerFile = new File(pathToFile(uuid));
 		if (!playerFile.exists()) {
 			Bukkit.getLogger().fine("Player has no log file. Creating new file.");
 			PlayerStats log = new PlayerStats(uuid);
-//			SavePlayerStatsToFile(log);
 			return log;
 		}
 		InputStreamReader isReader;
@@ -95,7 +95,34 @@ public abstract class PlayerStatsFileManager {
 		return null;
 	}
 
-	private static String pathToFile(UUID uuid) {
+	private String pathToFile(UUID uuid) {
 		return FOLDER_LOCATION + uuid.toString() + ".json";
+	}
+
+	@Override
+	/**
+	 * Used for returning all the stored data for a player.
+	 * 
+	 * @param uuid
+	 * @return
+	 */
+	public PlayerStats GetPlayerStats(UUID uuid) {
+		return readPlayerStatsFromFile(uuid);
+	}
+
+	@Override
+	/**
+	 * Adds the session to the stored file.
+	 * 
+	 * In the future this will hopefully only post request with the session json as
+	 * the body and the backend will handle adding it to the list.
+	 * 
+	 * @param uuid
+	 * @param session
+	 */
+	public void PostSession(UUID uuid, Session session) {
+		PlayerStats ps = readPlayerStatsFromFile(uuid);
+		ps.GetSessions().add(session);
+		savePlayerStatsToFile(ps);
 	}
 }

--- a/CCSActivityTracker/src/org/cinemacraftstudios/PlayerStats/PlayerStatsListener.java
+++ b/CCSActivityTracker/src/org/cinemacraftstudios/PlayerStats/PlayerStatsListener.java
@@ -53,7 +53,7 @@ public class PlayerStatsListener implements Listener {
 		String msg = event.getMessage();
 		if (msg.startsWith("//")) {
 			UUID uuid = event.getPlayer().getUniqueId();
-			playerStatsManager.GetSession(uuid).bukkitCommandsUsed++;
+			playerStatsManager.GetSession(uuid).worldEditCommandsUsed++;
 		}
 	}
 }

--- a/CCSActivityTracker/src/org/cinemacraftstudios/PlayerStats/PlayerStatsListener.java
+++ b/CCSActivityTracker/src/org/cinemacraftstudios/PlayerStats/PlayerStatsListener.java
@@ -1,0 +1,59 @@
+package org.cinemacraftstudios.PlayerStats;
+
+import java.util.UUID;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * Handles the contruction and destruction of the PlayerStats instances. To
+ * conserve memory and performance only the players that are logged in are
+ * stored in memory.
+ * 
+ * @author Simon U.
+ * 
+ */
+public class PlayerStatsListener implements Listener {
+
+	PlayerStatsManager playerStatsManager = PlayerStatsManager.getInstance();
+
+	@EventHandler
+	public void onPlayerJoin(PlayerJoinEvent event) {
+		playerStatsManager.AddSession(event.getPlayer().getUniqueId());
+	}
+
+	/**
+	 * Remove the PlayerStats from the HashMap and set the end date for the session.
+	 * 
+	 * @param event
+	 */
+	@EventHandler
+	public void onPlayerQuit(PlayerQuitEvent event) {
+		playerStatsManager.RemoveSession(event.getPlayer().getUniqueId());
+	}
+
+	@EventHandler
+	public void onBlockPlace(BlockPlaceEvent event) {
+		UUID uuid = event.getPlayer().getUniqueId();
+		playerStatsManager.GetSession(uuid).blocksPlaced++;
+	}
+
+	/**
+	 * Gets called every time a player executes a command if two slashes are found
+	 * in the beginning of a message then increase the bukkitCommandsUsed count
+	 * 
+	 * @param event
+	 */
+	@EventHandler
+	public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event) {
+		String msg = event.getMessage();
+		if (msg.startsWith("//")) {
+			UUID uuid = event.getPlayer().getUniqueId();
+			playerStatsManager.GetSession(uuid).bukkitCommandsUsed++;
+		}
+	}
+}

--- a/CCSActivityTracker/src/org/cinemacraftstudios/PlayerStats/Session.java
+++ b/CCSActivityTracker/src/org/cinemacraftstudios/PlayerStats/Session.java
@@ -12,6 +12,6 @@ public class Session {
 	public Date start;
 	public Date end;
 	public int blocksPlaced = 0;
-	public int bukkitCommandsUsed = 0;
+	public int worldEditCommandsUsed = 0;
 	public int blocksChangedWorldEdit = 0;
 }

--- a/CCSActivityTracker/src/org/cinemacraftstudios/PlayerStats/Session.java
+++ b/CCSActivityTracker/src/org/cinemacraftstudios/PlayerStats/Session.java
@@ -3,6 +3,7 @@ package org.cinemacraftstudios.PlayerStats;
 import java.util.Date;
 
 /**
+ * The place where all of the data for each session is stored.
  * 
  * @author Simon U.
  * 
@@ -12,4 +13,5 @@ public class Session {
 	public Date end;
 	public int blocksPlaced = 0;
 	public int bukkitCommandsUsed = 0;
+	public int blocksChangedWorldEdit = 0;
 }

--- a/CCSActivityTracker/src/org/cinemacraftstudios/WorldEditIntegration/WorldEditHook.java
+++ b/CCSActivityTracker/src/org/cinemacraftstudios/WorldEditIntegration/WorldEditHook.java
@@ -1,0 +1,46 @@
+package org.cinemacraftstudios.WorldEditIntegration;
+
+import com.sk89q.worldedit.EditSession.Stage;
+
+import java.util.UUID;
+
+import org.cinemacraftstudios.PlayerStats.PlayerStatsManager;
+import org.cinemacraftstudios.PlayerStats.Session;
+
+import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.blocks.BaseBlock;
+import com.sk89q.worldedit.event.extent.EditSessionEvent;
+import com.sk89q.worldedit.extent.AbstractDelegateExtent;
+import com.sk89q.worldedit.util.eventbus.Subscribe;
+
+/**
+ * Interfaces with worldedit
+ * 
+ * @author Simon
+ *
+ */
+public class WorldEditHook {
+
+	@Subscribe
+	public void wrapForBlockCounting(EditSessionEvent event) {
+
+		event.setExtent(new AbstractDelegateExtent(event.getExtent()) {
+
+			UUID uuid = event.getActor().getUniqueId();
+			Session session = PlayerStatsManager.getInstance().GetSession(uuid);
+
+			@Override
+			/**
+			 * Gets Called for every block that if affected by a worldedit command
+			 */
+			public boolean setBlock(Vector location, BaseBlock block) throws WorldEditException {
+				if (event.getStage() == Stage.BEFORE_CHANGE) {
+					session.blocksChangedWorldEdit++;
+				}
+				return getExtent().setBlock(location, block);
+			}
+
+		});
+	}
+}

--- a/CCSActivityTracker/src/org/cinemacraftstudios/api/APIInterface.java
+++ b/CCSActivityTracker/src/org/cinemacraftstudios/api/APIInterface.java
@@ -1,0 +1,18 @@
+package org.cinemacraftstudios.api;
+
+import java.util.UUID;
+
+import org.cinemacraftstudios.PlayerStats.PlayerStats;
+import org.cinemacraftstudios.PlayerStats.Session;
+
+/**
+ * Handles storage of Sessions. Delegates
+ * 
+ * @author Simon
+ *
+ */
+public interface APIInterface {
+	public PlayerStats GetPlayerStats(UUID uuid);
+
+	public void PostSession(UUID uuid, Session session);
+}

--- a/CCSActivityTracker/src/org/cinemacraftstudios/main/CCSActivityTracker.java
+++ b/CCSActivityTracker/src/org/cinemacraftstudios/main/CCSActivityTracker.java
@@ -1,7 +1,11 @@
 package org.cinemacraftstudios.main;
 
 import org.bukkit.plugin.java.JavaPlugin;
-import org.cinemacraftstudios.PlayerStats.PlayerStatsManager;
+import org.cinemacraftstudios.PlayerStats.PlayerStatsListener;
+import org.cinemacraftstudios.WorldEditIntegration.WorldEditHook;
+
+import com.sk89q.worldedit.WorldEdit;
+
 
 /**
  * 
@@ -13,7 +17,9 @@ public class CCSActivityTracker extends JavaPlugin {
 
 	public void onEnable() {
 		System.out.println("Hello there");
-		getServer().getPluginManager().registerEvents(new PlayerStatsManager(), this);
+		getServer().getPluginManager().registerEvents(new PlayerStatsListener(), this);
+
+		WorldEdit.getInstance().getEventBus().register(new WorldEditHook());
 	}
 
 	@Override


### PR DESCRIPTION
Adds Worldedit integration, so we can get exactly how many blocks have been affected by the player.
And the way the saving to the file system is called is revamped so it's easily replaceable with the real backend.
Split PlayerStatsManager into PlayerStatsManager and PlayerStatsListener.